### PR TITLE
Implement a `Node` trait

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,8 @@
 name: Security Audit
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
 env:
     CARGO_TERM_COLOR: always
 permissions: {}
@@ -20,7 +22,7 @@ jobs:
                   persist-credentials: false
 
             - name: Install cargo-audit
-              run: cargo install cargo-audit@0.22.1 --locked
+              run: cargo install cargo-audit --locked
 
             - name: Check for audit warnings
               run: cargo audit -D warnings

--- a/.github/workflows/signatures.yml
+++ b/.github/workflows/signatures.yml
@@ -23,4 +23,4 @@ jobs:
               uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
             - name: Check commit signatures
-              run: just check-sigs
+              run: bash contrib/check-signatures.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "halfin"
 version = "0.1.0"
+name = "halfin"
+description = "A (regtest) bitcoin node runner 🏃‍♂️"
 authors = ["Luis Schwab <dev@luisschwab.net"]
 repository = "https://github.com/luisschwab/halfin"
-description = "A (regtest) bitcoin node runner 🏃‍♂️"
+documentation = "https://docs.rs/halfin"
 keywords = ["bitcoin", "runner", "testing"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # halfin
 
+<p>
+    <a href="https://crates.io/crates/halfin"><img src="https://img.shields.io/crates/v/halfin.svg"/></a>
+    <a href="https://docs.rs/halfin"><img src="https://img.shields.io/badge/docs.rs-halfin-green"/></a>
+    <a href="https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/"><img src="https://img.shields.io/badge/rustc-1.85.0%2B-orange.svg?label=MSRV"/></a>
+    <a href="https://github.com/luisschwab/halfin/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-MIT%2FApache--2.0-red.svg"/></a>
+    <a href="https://github.com/luisschwab/halfin/actions/workflows/rust.yml"><img src="https://github.com/luisschwab/halfin/actions/workflows/rust.yml/badge.svg"></a>
+</p>
+
 > A (regtest) bitcoin node runner 🏃‍♂️
 
 This crate makes it simple to run regtest `bitcoind` and `utreexod` instances from Rust code
 in integration test contexts. Pretty much [`corepc_node`](https://crates.io/crates/corepc-node) 
-with `utreexod` support.
+with [`utreexod`](https://github.com/utreexo/utreexod) support.
 
 ## Supported Implementations and Versions
 
-| Feature           | Implementation | Version(s) |
-|-------------------|----------------|------------|
-| `bitcoind_30_2`   | `bitcoind`     | v30.2      |
-| `utreexod_0_5_0`  | `utreexod`     | v0.5.0     |
+| Implementation | Version  | Feature Flag     |
+|----------------|----------|----------------- |
+| [`bitcoind`]   | `v30.2`  | `bitcoind_30_2`  |
+| [`utreexod`]   | `v0.5.0` | `utreexod_0_5_0` |
 
-Both features are enabled by default. Binaries are downloaded automatically at build time, see [`build.rs`](./build.rs).
+By default, the `bitcoind_30_2` and `utreexod_0_5_0` features are enabled.
+
+Binaries are downloaded automatically at build time: see [`build.rs`](./build.rs).
 
 ## BitcoinD
 

--- a/build.rs
+++ b/build.rs
@@ -109,9 +109,6 @@ mod bitcoind {
         let expected_hash = get_expected_sha256(&download_filename);
 
         if existing_filename.exists() {
-            println!(
-                "cargo:warning=Found cached `bitcoind` under `/target/bin/`, skipping download"
-            );
             return;
         } else {
             println!(
@@ -316,9 +313,6 @@ mod utreexod {
         let expected_hash = get_expected_sha256(&download_filename);
 
         if existing_filename.exists() {
-            println!(
-                "cargo:warning=Found cached `utreexod` under `/target/bin/`, skipping download"
-            );
             return;
         } else {
             println!(

--- a/contrib/check-signatures.sh
+++ b/contrib/check-signatures.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script will check if all commits in this branch are PGP-signed.
+
+set -euo pipefail
+
+BASE=${1:-origin/master}
+RANGE="$BASE..HEAD"
+
+TOTAL=$(git log --pretty='tformat:%H' "$RANGE" | wc -l | tr -d ' ')
+UNSIGNED=$(git log --pretty='tformat:%H %G?' "$RANGE" | awk '$2 == "N" {count++} END {print count+0}')
+
+if [ "$UNSIGNED" -gt 0 ]; then
+    echo "⚠️ Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
+    exit 1
+else
+    echo "🔏 All commits in this branch are signed [$TOTAL/$TOTAL]"
+fi

--- a/justfile
+++ b/justfile
@@ -26,15 +26,7 @@ check:
 
 [doc: "Checks whether all commits in this branch are signed"]
 check-sigs:
-    #!/usr/bin/env bash
-    TOTAL=$(git log --pretty='tformat:%H' origin/master..HEAD | wc -l | tr -d ' ')
-    UNSIGNED=$(git log --pretty='tformat:%H %G?' origin/master..HEAD | grep " N$" | wc -l | tr -d ' ')
-    if [ "$UNSIGNED" -gt 0 ]; then
-        echo "⚠️ Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
-        exit 1
-    else
-        echo "🔏 All commits in this branch are signed [$TOTAL/$TOTAL]"
-    fi
+    bash contrib/check-signatures.sh
 
 [doc: "Delete binaries under `target/bin/`"]
 delete-bins:

--- a/justfile
+++ b/justfile
@@ -52,8 +52,7 @@ lock:
 
 [doc: "Run tests across all toolchains and lockfiles"]
 test:
-    cargo rbmt test --toolchain stable --lock-file recent
-    cargo rbmt test --toolchain stable --lock-file minimal
+    cargo rbmt test
 
 [doc: "Run pre-push suite: lock, fmt, check, and test"]
 pre-push: lock fmt check check-sigs test

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -52,12 +52,8 @@ use tempfile::TempDir;
 use crate::DataDir;
 use crate::Error;
 use crate::LOCALHOST;
-use crate::MAX_RETRIES_NODE_BUILDING;
+use crate::NODE_BUILDING_MAX_RETRIES;
 use crate::get_available_port;
-
-pub use serde_json;
-pub use tempfile;
-pub use which;
 
 /// Name of the wallet created (or loaded) inside every [`BitcoinD`] instance.
 const BITCOIND_WALLET: &str = "wallet";
@@ -100,7 +96,7 @@ pub struct BitcoinDConf<'a> {
     /// How many times to retry spawning `bitcoind` before giving up.
     ///
     /// Each attempt picks fresh random ports, so transient port-collision
-    /// errors are automatically recovered from. Defaults to [`MAX_RETRIES_NODE_BUILDING`].
+    /// errors are automatically recovered from. Defaults to [`NODE_BUILDING_MAX_RETRIES`].
     pub max_retries: u8,
 }
 
@@ -110,7 +106,7 @@ impl Default for BitcoinDConf<'_> {
             args: vec!["-regtest", "-fallbackfee=0.0001"],
             tmpdir: None,
             staticdir: None,
-            max_retries: MAX_RETRIES_NODE_BUILDING,
+            max_retries: NODE_BUILDING_MAX_RETRIES,
         }
     }
 }
@@ -390,14 +386,17 @@ impl BitcoinD {
     }
 
     /// Generate `count` blocks.
-    pub fn generate(&self, count: usize) -> Result<(), Error> {
+    ///
+    /// Returns a the block hashes as a [`Vec<String>`].
+    pub fn generate(&self, count: u32) -> Result<Vec<String>, Error> {
         let address = self.rpc_client.new_address().map_err(Error::JsonRpc)?;
-        let _hashes = self
+        let hashes = self
             .rpc_client
-            .generate_to_address(count, &address)
-            .map_err(Error::JsonRpc)?;
+            .generate_to_address(count as usize, &address)
+            .map_err(Error::JsonRpc)?
+            .0;
 
-        Ok(())
+        Ok(hashes)
     }
 
     // ----> INTERNAL
@@ -491,20 +490,9 @@ pub fn get_bitcoind_path() -> Result<PathBuf, Error> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::wait_for_height;
 
-    /// Block the calling thread until `node` reaches at least `height`, or panic after 10 seconds.
-    fn wait_for_height(node: &BitcoinD, height: u32) {
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        while start.elapsed() < timeout {
-            if node.get_height().unwrap() >= height {
-                return;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-        panic!("timeout waiting for node to reach height {}", height);
-    }
+    use super::*;
 
     /// Verify that [`BitcoinD`] starts successfully and exposes its PID, working directory, and P2P socket
     #[test]
@@ -564,11 +552,11 @@ mod test {
             .add_peer(bitcoind_beta.get_p2p_socket())
             .unwrap();
 
-        wait_for_height(&bitcoind_beta, 21);
+        wait_for_height(&bitcoind_beta, 21).unwrap();
         assert_eq!(bitcoind_beta.get_height().unwrap(), 21);
 
         bitcoind_beta.generate(21).unwrap();
-        wait_for_height(&bitcoind_alpha, 42);
+        wait_for_height(&bitcoind_alpha, 42).unwrap();
         assert_eq!(bitcoind_alpha.get_height().unwrap(), 42);
     }
 }

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -259,7 +259,7 @@ impl BitcoinD {
             let rpc_client = loop {
                 if Instant::now() > deadline {
                     let _ = process.kill();
-                    return Err(Error::WalletTimeout);
+                    continue;
                 }
                 if client_base.create_wallet(BITCOIND_WALLET).is_ok()
                     || client_base.load_wallet(BITCOIND_WALLET).is_ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,9 @@ impl DataDir {
 pub enum Error {
     /// The binary was not found at the expected location.
     BinaryNotFound(PathBuf),
-    /// Failed to spawn a [process](std::process::Child) for [`BitcoinD`] or [`UtreexoD`].
+    /// Failed to spawn a [process](std::process::Child) for [`BitcoinD`]/[`UtreexoD`].
     FailedToSpawn(std::io::Error),
-    /// Timed out whilst creating or loading [`BitcoinD`]'s or [`UtreexoD`]'s wallet.
-    WalletTimeout,
-    /// Failed to instantiate [`BitcoinD`] or [`UtreexoD`] after [`MAX_RETRIES_NODE_BUILDING`] attempts.
+    /// Failed to instantiate a [`BitcoinD`]/[`UtreexoD`] after [`NODE_BUILDING_MAX_RETRIES`] attempts.
     ExhaustedNodeBuildingRetries,
     /// Failed to stop [`BitcoinD`] or [`UtreexoD`] over JSON-RPC (e.g. `bitcoin-cli -regtest stop`).
     FailedToStop(corepc_client::client_sync::Error),
@@ -121,8 +119,7 @@ impl fmt::Display for Error {
         match self {
             BinaryNotFound(path) => write!(f, "The `utreexod` binary was not found at the expected location: {}", path.display()),
             FailedToSpawn(err) => write!(f, "Failed to spawn a process for the node: {err:?}"),
-            WalletTimeout => write!(f, "Timed out whilst creating or loading a wallet"),
-            ExhaustedNodeBuildingRetries => write!(f, "Failed to instantiate the node after {} attempts", MAX_RETRIES_NODE_BUILDING),
+            ExhaustedNodeBuildingRetries => write!(f, "Failed to instantiate the node after {} attempts", NODE_BUILDING_MAX_RETRIES),
             FailedToStop(err) => write!(f, "Failed to stop the node over JSON-RPC: {err:?}"),
             Io(err) => write!(f, "I/O Error: {err:?}"),
             JsonRpc(err) => write!(f, "JSON-RPC Error: {err:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@
 //!
 //! ## Supported Implementations and Versions
 //!
-//! | Implementation | Versions | Feature Flag   |
-//! |----------------|----------|--------------- |
-//! | [`bitcoind`]   | v30.2    | bitcoind_30_2  |
-//! | [`utreexod`]   | v0.5.0   | utreexod_0_5_0 |
+//! | Implementation | Version  | Feature Flag     |
+//! |----------------|----------|----------------- |
+//! | [`bitcoind`]   | `v30.2`  | `bitcoind_30_2`  |
+//! | [`utreexod`]   | `v0.5.0` | `utreexod_0_5_0` |
 //!
 //! ## Example
 //!
@@ -27,11 +27,15 @@
 //! [`bitcoind`]: <https://github.com/bitcoin/bitcoin>
 //! [`utreexod`]: <https://github.com/utreexo/utreexod>
 
+use core::error;
 use core::fmt;
 use core::net::Ipv4Addr;
 use core::net::SocketAddr;
 use std::net::TcpListener;
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
 use tempfile::TempDir;
 
 pub use bitcoind::BitcoinD;
@@ -43,8 +47,96 @@ pub mod utreexod;
 /// IPv4 Localhost address.
 const LOCALHOST: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 
-/// The maximum number of attempts at instantiating a [`BitcoinD`] or [`UtreexoD`].
-pub const MAX_RETRIES_NODE_BUILDING: u8 = 5;
+/// The maximum number of attempts at instantiating a [`BitcoinD`]/[`UtreexoD`].
+pub const NODE_BUILDING_MAX_RETRIES: u8 = 5;
+
+/// The [`Duration`] between polls for `wait_for_height`.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// The timeout [`Duration`] for `wait_for_height`.
+pub const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Common interface across all node implementations ([`BitcoinD`]/[`UtreexoD`]).
+pub trait Node {
+    /// A human-readable name for the [`Node`].
+    fn get_name() -> &'static str;
+
+    /// Get the [`Node`]'s current chain height.
+    fn get_height(&self) -> Result<u32, Error>;
+
+    /// How long to sleep between `get_height` RPC calls.
+    ///
+    /// Defaults to [`POLL_INTERVAL`].
+    ///
+    /// Override for nodes that need a longer settling time between RPC calls.
+    fn poll_interval() -> Duration {
+        POLL_INTERVAL
+    }
+
+    /// How long `wait_for_height` will poll before giving up.
+    ///
+    /// Defaults to [`WAIT_TIMEOUT`].
+    ///
+    /// Override for nodes that need more time to process blocks
+    /// (e.g. [`UtreexoD`] needs more time to build the Merkle forest).
+    fn wait_timeout() -> Duration {
+        WAIT_TIMEOUT
+    }
+}
+
+#[rustfmt::skip]
+impl Node for BitcoinD {
+    fn get_name() -> &'static str { "bitcoind" }
+    fn get_height(&self) -> Result<u32, Error> { self.get_height() }
+}
+
+#[rustfmt::skip]
+impl Node for UtreexoD {
+    fn get_name() -> &'static str { "utreexod" }
+    fn get_height(&self) -> Result<u32, Error> { self.get_height() }
+    fn poll_interval() -> Duration { 2 * POLL_INTERVAL }
+    fn wait_timeout() -> Duration { 2 * WAIT_TIMEOUT }
+}
+
+/// Poll a [`Node`] until its chain height reaches `height`, then return.
+///
+/// Panics if the node does not reach `height` within [`Node::wait_timeout`].
+pub fn wait_for_height<N: Node>(node: &N, height: u32) -> Result<(), Error> {
+    let start = Instant::now();
+    while start.elapsed() < N::wait_timeout() {
+        if node.get_height().unwrap() >= height {
+            return Ok(());
+        }
+        thread::sleep(N::poll_interval());
+    }
+
+    let curr_height = node.get_height().unwrap();
+    Err(Error::ChainSyncTimeOut((
+        height,
+        curr_height,
+        N::wait_timeout(),
+    )))
+}
+
+/// Poll a [`Node`] until its chain height reaches `height`, then return.
+///
+/// Panics if the node does not reach `height` within `timeout`.
+pub fn wait_for_height_with_timeout<N: Node>(
+    node: &N,
+    height: u32,
+    timeout: Duration,
+) -> Result<(), Error> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if node.get_height().unwrap() >= height {
+            return Ok(());
+        }
+        thread::sleep(N::poll_interval());
+    }
+
+    let curr_height = node.get_height().unwrap();
+    Err(Error::ChainSyncTimeOut((height, curr_height, timeout)))
+}
 
 /// Ask the OS for an available port, immediately unbind and return it.
 ///
@@ -110,6 +202,8 @@ pub enum Error {
     RpcClientSetupTimeout,
     /// Received an unexpected response from the JSON-RPC server
     UnexpectedResponse,
+    /// Timed out whilst waiting for the [`Node`]'s chain to synchronize up to `height`
+    ChainSyncTimeOut((u32, u32, Duration)), // (current_height, target_height, timeout)
 }
 
 #[rustfmt::skip]
@@ -130,6 +224,13 @@ impl fmt::Display for Error {
             CookieFileTimeout(cookie_path) => write!(f, "Timed out whilst waiting for the cookie={} to be generated", cookie_path.display()),
             RpcClientSetupTimeout => write!(f, "Timed out whilst waiting for the JSON-RPC client to be ready"),
             UnexpectedResponse => write!(f, "Received an unexpected response from the JSON-RPC server"),
+            ChainSyncTimeOut((target_height, current_height, t)) => write!(
+                f,
+                "Timed out after {} seconds whilst waiting for the node's chain to synchronize to height={} (current height={})",
+                target_height, current_height, t.as_secs()
+            ),
         }
     }
 }
+
+impl error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ const LOCALHOST: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 pub const MAX_RETRIES_NODE_BUILDING: u8 = 5;
 
 /// Ask the OS for an available port, immediately unbind and return it.
+///
+/// Inlining is needed to curb TOCTOU race conditions.
+#[inline]
 pub fn get_available_port() -> u16 {
     TcpListener::bind((LOCALHOST, 0))
         .unwrap()

--- a/src/utreexod/mod.rs
+++ b/src/utreexod/mod.rs
@@ -15,8 +15,6 @@
 //! let node = UtreexoD::download_new().unwrap();
 //! ```
 
-mod versions;
-
 use core::net::SocketAddr;
 use core::net::SocketAddrV4;
 use std::env;
@@ -39,13 +37,15 @@ use tempfile::TempDir;
 use crate::DataDir;
 use crate::Error;
 use crate::LOCALHOST;
-use crate::MAX_RETRIES_NODE_BUILDING;
+use crate::NODE_BUILDING_MAX_RETRIES;
 use crate::get_available_port;
 
-/// Username used for RPC authentication with `utreexod`.
+mod versions;
+
+/// Username for RPC authentication.
 const RPC_USER: &str = "halfin";
 
-/// Password used for RPC authentication with `utreexod`.
+/// Password for RPC authentication.
 const RPC_PASS: &str = "halfin";
 
 /// Configuration for a [`UtreexoD`] instance.
@@ -86,7 +86,7 @@ pub struct UtreexoDConf<'a> {
     /// How many times to retry spawning `utreexod` before giving up.
     ///
     /// Each attempt picks fresh random ports, so transient port-collision
-    /// errors are automatically recovered from. Defaults to [`MAX_RETRIES_NODE_BUILDING`].
+    /// errors are automatically recovered from. Defaults to [`NODE_BUILDING_MAX_RETRIES`].
     pub max_retries: u8,
 }
 
@@ -102,7 +102,7 @@ impl Default for UtreexoDConf<'_> {
             ],
             tmpdir: None,
             staticdir: None,
-            max_retries: MAX_RETRIES_NODE_BUILDING,
+            max_retries: NODE_BUILDING_MAX_RETRIES,
         }
     }
 }
@@ -356,7 +356,7 @@ impl UtreexoD {
     }
 
     /// Generate `count` blocks.
-    pub fn generate(&self, count: usize) -> Result<(), Error> {
+    pub fn generate(&self, count: u32) -> Result<(), Error> {
         self.rpc_client
             .call::<serde_json::Value>("generate", &[serde_json::to_value(count).unwrap()])
             .map_err(Error::JsonRpc)?;
@@ -434,22 +434,11 @@ pub fn get_utreexod_path() -> Result<PathBuf, Error> {
 
 #[cfg(test)]
 mod test {
+    use crate::wait_for_height;
+
     use super::*;
 
-    /// Block the calling thread until `node` reaches at least `height`, or panic after 10 seconds.
-    fn wait_for_height(node: &UtreexoD, height: u32) {
-        let timeout = Duration::from_secs(30);
-        let start = Instant::now();
-        while start.elapsed() < timeout {
-            if node.get_height().unwrap() >= height {
-                return;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-        panic!("timeout waiting for node to reach height {}", height);
-    }
-
-    /// Verify that [`UtreexoD`] starts successfully and exposes its PID, working directory, and P2P socket
+    /// Verify that [`UtreexoD`] starts successfully and exposes its PID, working directory, and P2P socket.
     #[test]
     fn test_utreexod_starts() {
         let bin = get_utreexod_path().unwrap();
@@ -474,8 +463,8 @@ mod test {
         assert_eq!(height, 10);
     }
 
-    /// Verify that two nodes can connect to each other via `add_peer` and
-    /// that the peer count reflects the new connection on both sides.
+    /// Verify that two nodes can connect to each other via `add_peer`,
+    /// and that the peer count reflects the new connection on both sides.
     #[test]
     fn test_utreexod_addnode() {
         let utreexod_alpha = UtreexoD::download_new().unwrap();
@@ -492,7 +481,7 @@ mod test {
         assert_eq!(utreexod_beta.get_peer_count().unwrap(), 1);
     }
 
-    /// Verify that blocks mined on one node propagate to a connected peer.
+    /// Verify that mined blocks propagate to a connected peer.
     #[test]
     fn test_utreexod_blocks_propagate() {
         let utreexod_alpha = UtreexoD::download_new().unwrap();
@@ -507,11 +496,11 @@ mod test {
             .add_peer(utreexod_beta.get_p2p_socket())
             .unwrap();
 
-        wait_for_height(&utreexod_beta, 21);
+        wait_for_height(&utreexod_beta, 21).unwrap();
         assert_eq!(utreexod_beta.get_height().unwrap(), 21);
 
         utreexod_beta.generate(21).unwrap();
-        wait_for_height(&utreexod_alpha, 42);
+        wait_for_height(&utreexod_alpha, 42).unwrap();
         assert_eq!(utreexod_alpha.get_height().unwrap(), 42);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,26 +2,11 @@
 
 //! Integration tests between [`BitcoinD`] and [`UtreexoD`].
 
-use std::thread;
-use std::time::Duration;
-use std::time::Instant;
-
 use halfin::bitcoind::BitcoinD;
 use halfin::utreexod::UtreexoD;
+use halfin::wait_for_height;
 
-fn wait_for_height(node: &UtreexoD, height: u32) {
-    let timeout = Duration::from_secs(10);
-    let start = Instant::now();
-    while start.elapsed() < timeout {
-        if node.get_height().unwrap() >= height {
-            return;
-        }
-        thread::sleep(Duration::from_millis(200));
-    }
-    panic!("timeout waiting for utreexod to reach height {}", height);
-}
-
-/// Verify that a [`BitcoinD`] and [`UtreexoD`] node can connect to each other.
+/// Verify that [`BitcoinD`] and [`UtreexoD`] can connect to each other.
 #[test]
 fn test_bitcoind_utreexod_addnode() {
     let bitcoind = BitcoinD::download_new().unwrap();
@@ -48,7 +33,7 @@ fn test_bitcoind_blocks_propagate_to_utreexod() {
 
     utreexod.add_peer(bitcoind.get_p2p_socket()).unwrap();
 
-    wait_for_height(&utreexod, 21);
+    wait_for_height(&utreexod, 21).unwrap();
     assert_eq!(utreexod.get_height().unwrap(), 21);
 }
 
@@ -76,10 +61,10 @@ fn test_bitcoind_utreexod_chain_sync() {
     println!("utreexod peers: {:#?}", utreexod_peers);
 
     bitcoind.generate(10).unwrap();
-    wait_for_height(&utreexod, 10);
+    wait_for_height(&utreexod, 10).unwrap();
     assert_eq!(utreexod.get_height().unwrap(), 10);
 
     bitcoind.generate(10).unwrap();
-    wait_for_height(&utreexod, 20);
+    wait_for_height(&utreexod, 20).unwrap();
     assert_eq!(utreexod.get_height().unwrap(), 20);
 }


### PR DESCRIPTION
Closes #9

## Changelog
```
- Add a `Node` trait with shared methods, which both `BitcoinD` and `UtreexoD` implement
- Add `wait_for_height` and `wait_for_height_with_timeout`
- Add badges to the README
- Fix TOCTOU race condition on `get_available_port` by `#[inline]`ing the function
- Drop `extractions/setup-just` dep from CI
- Remove unnecessary `Error::WalletTimeout` variant and continue in case of `BitcoinD::from_bin_with_conf` failure
```