### PR TITLE
Emit `HALFIN_BITCOIND_PATH` and `HALFIN_UTREEXOD_PATH` at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@
 
 > A (regtest) bitcoin node runner 🏃‍♂️
 
-This crate makes it simple to run regtest `bitcoind` and `utreexod` instances from Rust code
-in integration test contexts. Pretty much [`corepc_node`](https://crates.io/crates/corepc-node) 
+This crate makes it simple to run regtest [`bitcoind`](https://github.com/bitcoin/bitcoin)
+and [`utreexod`](https://github.com/utreexo/utreexod) instances from Rust code, useful in
+integration testing contexts.
+
+Pretty much [`corepc_node`](https://crates.io/crates/corepc-node)
 with [`utreexod`](https://github.com/utreexo/utreexod) support.
 
 ## Supported Implementations and Versions
 
 | Implementation | Version  | Feature Flag     |
 |----------------|----------|----------------- |
-| [`bitcoind`]   | `v30.2`  | `bitcoind_30_2`  |
-| [`utreexod`]   | `v0.5.0` | `utreexod_0_5_0` |
+| `bitcoind`     | `v30.2`  | `bitcoind_30_2`  |
+|                |          |                  |
+| `utreexod`     | `v0.5.0` | `utreexod_0_5_0` |
 
 By default, the `bitcoind_30_2` and `utreexod_0_5_0` features are enabled.
 

--- a/build.rs
+++ b/build.rs
@@ -110,6 +110,13 @@ mod bitcoind {
             .join(format!("bitcoin-{}", BITCOIND_VERSION))
             .join("bitcoind");
 
+        // Emit the binary path an an environment variable
+        // so that `get_bitcoind_path` picks it up.
+        println!(
+            "cargo:rustc-env=HALFIN_BITCOIND_PATH={}",
+            existing_filename.display()
+        );
+
         let download_filename = get_download_filename();
         let expected_hash = get_expected_sha256(&download_filename);
 
@@ -313,6 +320,13 @@ mod utreexod {
         let existing_filename = download_directory
             .join(format!("utreexod-{}", UTREEXOD_VERSION))
             .join("utreexod");
+
+        // Emit the binary path an an environment variable
+        // so that `get_utreexod_path` picks it up.
+        println!(
+            "cargo:rustc-env=HALFIN_UTREEXOD_PATH={}",
+            existing_filename.display()
+        );
 
         let download_filename = get_download_filename();
         let expected_hash = get_expected_sha256(&download_filename);

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -53,6 +53,7 @@ use crate::DataDir;
 use crate::Error;
 use crate::LOCALHOST;
 use crate::NODE_BUILDING_MAX_RETRIES;
+use crate::Node;
 use crate::get_available_port;
 
 /// Name of the wallet created (or loaded) inside every [`BitcoinD`] instance.
@@ -472,19 +473,16 @@ impl BitcoinD {
 }
 
 /// Return the path to the downloaded `bitcoind` binary.
+///
+/// The path is resolved at compile time from the `HALFIN_BITCOIND_PATH`
+/// environment variable, which is set by `build.rs` after downloading
+/// and extracting the binary.
 pub fn get_bitcoind_path() -> Result<PathBuf, Error> {
-    use versions::BITCOIND_VERSION;
-
-    let mut bin_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join("bin");
-
-    bin_path.push(format!("bitcoin-{}", BITCOIND_VERSION));
-    bin_path.push("bitcoind");
-
+    let bin_name = BitcoinD::get_name().to_string();
+    let bin_path = PathBuf::from(option_env!("HALFIN_BITCOIND_PATH").unwrap_or(""));
     match bin_path.exists() {
         true => Ok(bin_path),
-        false => Err(Error::BinaryNotFound(bin_path)),
+        false => Err(Error::BinaryNotFound((bin_name, bin_path))),
     }
 }
 

--- a/src/bitcoind/versions.rs
+++ b/src/bitcoind/versions.rs
@@ -1,2 +1,3 @@
 /// Bitcoin Core v30.2
+#[allow(unused)]
 pub const BITCOIND_VERSION: &str = "30.2";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl DataDir {
 #[derive(Debug)]
 pub enum Error {
     /// The binary was not found at the expected location.
-    BinaryNotFound(PathBuf),
+    BinaryNotFound((String, PathBuf)),
     /// Failed to spawn a [process](std::process::Child) for [`BitcoinD`]/[`UtreexoD`].
     FailedToSpawn(std::io::Error),
     /// Failed to instantiate a [`BitcoinD`]/[`UtreexoD`] after [`NODE_BUILDING_MAX_RETRIES`] attempts.
@@ -211,7 +211,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Error::*;
         match self {
-            BinaryNotFound(path) => write!(f, "The `utreexod` binary was not found at the expected location: {}", path.display()),
+            BinaryNotFound((bin_name, path)) => write!(f, "The `{}` binary was not found at the expected location={}", bin_name, path.display()),
             FailedToSpawn(err) => write!(f, "Failed to spawn a process for the node: {err:?}"),
             ExhaustedNodeBuildingRetries => write!(f, "Failed to instantiate the node after {} attempts", NODE_BUILDING_MAX_RETRIES),
             FailedToStop(err) => write!(f, "Failed to stop the node over JSON-RPC: {err:?}"),

--- a/src/utreexod/mod.rs
+++ b/src/utreexod/mod.rs
@@ -38,6 +38,7 @@ use crate::DataDir;
 use crate::Error;
 use crate::LOCALHOST;
 use crate::NODE_BUILDING_MAX_RETRIES;
+use crate::Node;
 use crate::get_available_port;
 
 mod versions;
@@ -413,22 +414,15 @@ impl UtreexoD {
 
 /// Return the path to the downloaded `utreexod` binary.
 ///
-/// Resolution order:
-/// 1. `UTREEXOD_DOWNLOAD_DIR` env var (joined with `utreexod-<VERSION>/utreexod`).
-/// 2. `<CARGO_MANIFEST_DIR>/target/bin/utreexod-<VERSION>/utreexod`.
+/// The path is resolved at compile time from the `HALFIN_UTREEXOD_PATH`
+/// environment variable, which is set by `build.rs` after downloading
+/// and extracting the binary.
 pub fn get_utreexod_path() -> Result<PathBuf, Error> {
-    use versions::UTREEXOD_VERSION;
-
-    let mut bin_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join("bin");
-
-    bin_path.push(format!("utreexod-{}", UTREEXOD_VERSION));
-    bin_path.push("utreexod");
-
+    let bin_name = UtreexoD::get_name().to_string();
+    let bin_path = PathBuf::from(option_env!("HALFIN_UTREEXOD_PATH").unwrap_or(""));
     match bin_path.exists() {
         true => Ok(bin_path),
-        false => Err(Error::BinaryNotFound(bin_path)),
+        false => Err(Error::BinaryNotFound((bin_name, bin_path))),
     }
 }
 

--- a/src/utreexod/versions.rs
+++ b/src/utreexod/versions.rs
@@ -1,4 +1,5 @@
 /// Utreexod v0.5.0
+#[allow(unused)]
 pub const UTREEXOD_VERSION: &str = "0.5.0";
 
 /// Utreexod v0.5.0 release date (for GitHub Endpoint)


### PR DESCRIPTION
Make `build.rs` emit `HALFIN_BITCOIND_PATH`/`HALFIN_UTREEXOD_PATH` at compile time via `build.rs` instead of relying on a hardcoded path under `target/bin`, which can fail on CI contexts due to caching.