### PR TITLE
Only download binaries for enabled features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 This crate makes it simple to run regtest [`bitcoind`](https://github.com/bitcoin/bitcoin)
 and [`utreexod`](https://github.com/utreexo/utreexod) instances from Rust code, useful in
-integration testing contexts.
+integration test contexts.
 
-Pretty much [`bitcoind`](https://crates.io/crates/bitcoind)
-with [`utreexod`](https://github.com/utreexo/utreexod) support.
+Pretty much [`bitcoind`](https://crates.io/crates/bitcoind) with 
+[`utreexod`](https://github.com/utreexo/utreexod) support.
 
 ## Supported Implementations and Versions
 
@@ -33,31 +33,7 @@ By default, the `bitcoind_31_0` and `utreexod_0_5_0` features are enabled.
 
 Binaries are downloaded automatically at build time: see [`build.rs`](./build.rs).
 
-## Running on CI environments
-
-Since [`utreexod`](https://github.com/utreexo/utreexod) binaries are downloaded directly
-from its GitHub releases page, we can get 403'ed by GitHub itself. To curb this, you need
-to export the `GITHUB_TOKEN` environment variable and give `read` permissions in your CI
-workflow, as such:
-
-```
-env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-permissions:
-    contents: read
-```
-
-The [`build.rs`](https://github.com/luisschwab/halfin/blob/master/build.rs) script
-automatically reads this variable from the environment and adds it as an
-`Authorization: Bearer $GITHUB_TOKEN` header when making requests to `github.com`.
-
-```rs
-if let Ok(token) = env::var("GITHUB_TOKEN") {
-    request = request.with_header("Authorization", format!("Bearer {}", token));
-}
-```
-
-## BitcoinD
+### BitcoinD
 
 ```rs
 use halfin::bitcoind::BitcoinD;
@@ -80,7 +56,7 @@ assert_eq!(bitcoind_alpha.get_height().unwrap(), 100);
 assert_eq!(bitcoind_beta.get_height().unwrap(), 100);
 ```
 
-## UtreexoD
+### UtreexoD
 
 ```rust
 use halfin::utreexod::UtreexoD;
@@ -89,6 +65,30 @@ let utreexod = UtreexoD::new().unwrap();
 
 utreexod.generate(10).unwrap();
 assert_eq!(utreexod.get_height().unwrap(), 10);
+```
+
+## Running on CI environments
+
+Since [`utreexod`](https://github.com/utreexo/utreexod) binaries are downloaded directly
+from its GitHub releases page, we can get 403'ed by GitHub itself. To curb this, you need
+to export the `GITHUB_TOKEN` environment variable and give `read` permissions in your CI
+workflow, as such:
+
+```
+env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+    contents: read
+```
+
+The [`build.rs`](./build.rs) script automatically reads this variable from the
+environment and adds it as an `Authorization: Bearer $GITHUB_TOKEN` header 
+when making requests to `github.com`.
+
+```rs
+if let Ok(token) = env::var("GITHUB_TOKEN") {
+    request = request.with_header("Authorization", format!("Bearer {}", token));
+}
 ```
 
 ## Developing
@@ -123,8 +123,7 @@ Available recipes:
     test        # Run tests across all toolchains and lockfiles [alias: t]
 ```
 
-
-## Minimum Supported Rust Version (MSRV)
+## Minimum Supported Rust Version
 
 This library should compile with any combination of features on Rust 1.85.0.
 

--- a/build.rs
+++ b/build.rs
@@ -5,11 +5,16 @@ fn main() {
     if std::env::var("DOCS_RS").is_ok() {
         return;
     }
-
-    // Check if `bitcoind` is cached and download it if not.
-    bitcoind::download();
-    // Check if `utreexod` is cached and download it if not.
-    utreexod::download();
+    // Skip if the `bitcoind_31_0` feature is not enabled.
+    if cfg!(feature = "bitcoind_31_0") {
+        // Check if `bitcoind` is cached and download it if not.
+        bitcoind::download();
+    }
+    // Skip if the `utreeoxd_0_5_0` feature is not enabled.
+    if cfg!(feature = "utreexod_0_5_0") {
+        // Check if `utreexod` is cached and download it if not.
+        utreexod::download();
+    }
 }
 
 /// Downloads  and verifies the `bitcoind` binary based on the enabled version feature.

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -504,7 +504,7 @@ pub fn get_bitcoind_path() -> Result<PathBuf, Error> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bitcoind_31_0"))]
 mod test {
     use crate::wait_for_height;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,15 @@
 //!
 //! A bitcoin node running utility for integration testing.
 //!
+//! > A {regtest} bitcoin node runner 🏃‍♂️
+//!
+//! This crate makes it simple to run regtest [`bitcoind`](https://github.com/bitcoin/bitcoin)
+//! and [`utreexod`](https://github.com/utreexo/utreexod) instances from Rust code, useful in
+//! integration test contexts.
+//!
+//! Pretty much [`bitcoind`](https://crates.io/crates/bitcoind) with
+//! [`utreexod`](https://github.com/utreexo/utreexod) support.
+//!
 //! ## Supported Implementations and Versions
 //!
 //! | Implementation | Version  | Feature Flag     |
@@ -40,8 +49,8 @@ use std::time::Duration;
 use std::time::Instant;
 use tempfile::TempDir;
 
-pub use bitcoind::BitcoinD;
-pub use utreexod::UtreexoD;
+use crate::bitcoind::BitcoinD;
+use crate::utreexod::UtreexoD;
 
 pub mod bitcoind;
 pub mod utreexod;
@@ -91,7 +100,7 @@ pub trait Node {
 
 #[rustfmt::skip]
 impl Node for BitcoinD {
-    fn get_name() -> &'static str { "bitcoind" }
+    fn get_name() -> &'static str { "bitcoind_v_31_0" }
 
     fn get_chain_tip(&self) -> Result<u32, Error> { self.get_chain_tip() }
 
@@ -100,7 +109,7 @@ impl Node for BitcoinD {
 
 #[rustfmt::skip]
 impl Node for UtreexoD {
-    fn get_name() -> &'static str { "utreexod" }
+    fn get_name() -> &'static str { "utreexod_v_0_5_0" }
 
     fn get_chain_tip(&self) -> Result<u32, Error> {
         let height = self.get_chain_tip()?;

--- a/src/utreexod/mod.rs
+++ b/src/utreexod/mod.rs
@@ -481,7 +481,7 @@ pub fn get_utreexod_path() -> Result<PathBuf, Error> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "utreexod_0_5_0"))]
 mod test {
     use crate::wait_for_height;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg(all(feature = "bitcoind_31_0", feature = "utreexod_0_5_0"))]
+
 //! Integration tests between [`BitcoinD`] and [`UtreexoD`].
 
 use std::thread::sleep;


### PR DESCRIPTION
## Changelog
```
- Feature gate `bitcoind::download()` and `utreexod::download()`
  on `build.rs` such that we don't download binaries uselessly.
```