### PR TITLE
Implement `connect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,25 @@ Binaries are downloaded automatically at build time: see [`build.rs`](./build.rs
 ### BitcoinD
 
 ```rs
+use halfin::connect;
 use halfin::bitcoind::BitcoinD;
 
-// Use downloaded/cached binaries
+// Use a downloaded binary
 let bitcoind_alpha = BitcoinD::new().unwrap();
+
 // Use a local binary
 let bin_path = PathBuf::from_str("/usr/local/bin/bitcoind").unwrap();
 let bitcoind_beta = BitcoinD::from_bin(&bin_path).unwrap();
 
 // Connect peers
-bitcoind_alpha.add_peer(bitcoind_beta.get_p2p_socket()).unwrap();
+connect(&bitcoind_alpha, &bitcoind_beta).unwrap()
 
 // Mine blocks
 bitcoind_alpha.generate(100).unwrap();
+assert_eq!(bitcoind_alpha.get_height().unwrap(), 100);
+
 // Wait for a node to catch up with the other
 wait_for_height(&bitcoind_beta, 100).unwrap();
-
-assert_eq!(bitcoind_alpha.get_height().unwrap(), 100);
 assert_eq!(bitcoind_beta.get_height().unwrap(), 100);
 ```
 
@@ -61,10 +63,15 @@ assert_eq!(bitcoind_beta.get_height().unwrap(), 100);
 ```rust
 use halfin::utreexod::UtreexoD;
 
+// Use a downloaded binary
 let utreexod = UtreexoD::new().unwrap();
 
-utreexod.generate(10).unwrap();
-assert_eq!(utreexod.get_height().unwrap(), 10);
+// Mine blocks
+utreexod.generate(100).unwrap();
+assert_eq!(utreexod.get_height().unwrap(), 100);
+
+// Raw call an unimplemented RPC
+let res = utreexod.call("uptime", &[]).unwrap();
 ```
 
 ## Running on CI environments
@@ -74,7 +81,7 @@ from its GitHub releases page, we can get 403'ed by GitHub itself. To curb this,
 to export the `GITHUB_TOKEN` environment variable and give `read` permissions in your CI
 workflow, as such:
 
-```
+```yml
 env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() {
     }
 }
 
-/// Downloads  and verifies the `bitcoind` binary based on the enabled version feature.
+/// Downloads and verifies the `bitcoind` binary based on the enabled version feature.
 ///
 /// Binaries are verified agains the corresponding SHA256SUM under `sha256/bitcoind`.
 ///

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -148,6 +148,10 @@ pub struct BitcoinD {
 impl Node for BitcoinD {
     fn get_name() -> &'static str { "bitcoind_v_31_0" }
 
+    fn get_p2p_socket(&self) -> SocketAddr { self.get_p2p_socket() }
+
+    fn add_peer(&self, socket: SocketAddr) -> Result<(), Error> { self.add_peer(socket) }
+
     fn get_chain_tip(&self) -> Result<u32, Error> { self.get_chain_tip() }
 
     fn get_block_hash(&self, height: u32) -> Result<BlockHash, Error> { self.get_block_hash(height) }
@@ -356,7 +360,7 @@ impl BitcoinD {
         Ok(hash)
     }
 
-    /// Connect this [`BitcoinD`] to another [`BitcoinD`] at `socket` and
+    /// Connect this [`BitcoinD`] to a peer at [`socket`](SocketAddr) and
     /// wait until the connection is established (up to 5 seconds with exponential back-off).
     ///
     /// Returns an error if the peer does not appear in `getpeerinfo` within the timeout.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! ## Example
 //!
 //! ```rust,no_run
+//! use halfin::connect;
 //! use halfin::bitcoind::BitcoinD;
 //! use halfin::utreexod::UtreexoD;
 //!
@@ -32,6 +33,8 @@
 //! let utreexod = UtreexoD::new().unwrap();
 //! utreexod.generate(10).unwrap();
 //! assert_eq!(utreexod.get_chain_tip().unwrap(), 10);
+//!
+//! connect(&bitcoind, &utreexod).unwrap();
 //! ```
 //!
 //! [`bitcoind`]: <https://github.com/bitcoin/bitcoin>
@@ -90,6 +93,12 @@ pub trait Node {
     /// [`Value`](serde_json::Value) into a meaningful type.
     fn call(&self, method: &str, args: &[serde_json::Value]) -> Result<serde_json::Value, Error>;
 
+    /// Get the [`Node`]'s P2P [`SocketAddr`].
+    fn get_p2p_socket(&self) -> SocketAddr;
+
+    /// Connect this [`Node`] to a peer at `socket` over P2P.
+    fn add_peer(&self, socket: SocketAddr) -> Result<(), Error>;
+
     /// How long to sleep between `get_height` RPC calls.
     ///
     /// Defaults to [`POLL_INTERVAL`].
@@ -110,9 +119,16 @@ pub trait Node {
     }
 }
 
-/// Poll a [`Node`] until its chain height reaches `height`, then return.
+/// Connect node [`a`](Node) to node [`b`](Node).
+pub fn connect<A: Node, B: Node>(a: &A, b: &B) -> Result<(), Error> {
+    let socket_b = b.get_p2p_socket();
+
+    a.add_peer(socket_b)
+}
+
+/// Poll a [`Node`] until its chain reaches `height`.
 ///
-/// Panics if the node does not reach `height` within [`Node::wait_timeout`].
+/// Throws an error if the node does not reach `height` within [`Node::wait_timeout`].
 pub fn wait_for_height<N: Node>(node: &N, height: u32) -> Result<(), Error> {
     let start = Instant::now();
     while start.elapsed() < N::wait_timeout() {
@@ -130,9 +146,9 @@ pub fn wait_for_height<N: Node>(node: &N, height: u32) -> Result<(), Error> {
     )))
 }
 
-/// Poll a [`Node`] until its chain height reaches `height`, then return.
+/// Poll a [`Node`] until its chain reaches `height` with a custom `timeout`.
 ///
-/// Panics if the node does not reach `height` within `timeout`.
+/// Throws an error if the node does not reach `height` within `timeout`.
 pub fn wait_for_height_with_timeout<N: Node>(
     node: &N,
     height: u32,

--- a/src/utreexod/mod.rs
+++ b/src/utreexod/mod.rs
@@ -144,11 +144,15 @@ pub struct UtreexoD {
 impl Node for UtreexoD {
     fn get_name() -> &'static str { "utreexod_v_0_5_0" }
 
+    fn get_p2p_socket(&self) -> SocketAddr { self.get_p2p_socket() }
+
+    fn add_peer(&self, socket: SocketAddr) -> Result<(), Error> { self.add_peer(socket) }
+
     fn get_chain_tip(&self) -> Result<u32, Error> {
         let height = self.get_chain_tip()?;
         if height == 0 {
             return Err(
-                Error::UnexpectedResponse("utreexod is at genesis, proof index not yet available".to_string())
+                Error::UnexpectedResponse("utreexod is at genesis, the proof index not ready yet".to_string())
             );
         }
         self.get_block_uproof(height)?;
@@ -355,11 +359,10 @@ impl UtreexoD {
         Ok(proof_hex)
     }
 
-    /// Connect this [`UtreexoD`] to a peer at `socket` and wait until the
-    /// connection is established (up to 5 seconds with exponential back-off).
+    /// Connect this [`UtreexoD`] to a peer at [`socket`](SocketAddr) and
+    /// wait until the connection is established (up to 5 seconds with exponential back-off).
     ///
-    /// Returns an error if the peer does not appear in `getpeerinfo` within
-    /// the timeout.
+    /// Returns an error if the peer does not appear in `getpeerinfo` within the timeout.
     pub fn add_peer(&self, socket: SocketAddr) -> Result<(), Error> {
         self.rpc_client
             .add_node(&socket.to_string(), AddNodeCommand::Add)

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use halfin::Node;
 use halfin::bitcoind::BitcoinD;
+use halfin::connect;
 use halfin::utreexod::UtreexoD;
 
 /// Verify that [`Node::call`] works by calling `uptime`.
@@ -23,4 +24,22 @@ fn test_node_call() {
 
     println!("bitcoind uptime: {}", bitcoind_uptime);
     println!("utreexod uptime: {}", utreexod_uptime);
+}
+
+/// Verify that [`connect`] connects any combination of [`Node`] implementations.
+#[test]
+fn test_connect() {
+    let bitcoind_1 = BitcoinD::new().unwrap();
+    sleep(Duration::from_millis(100));
+    let bitcoind_2 = BitcoinD::new().unwrap();
+    sleep(Duration::from_millis(100));
+    let utreexod_1 = UtreexoD::new().unwrap();
+    sleep(Duration::from_millis(100));
+    let utreexod_2 = UtreexoD::new().unwrap();
+
+    // .. > bitcoind_1 > bitcoind_2 > utreexod_1 > utreexod_2 > ..
+    connect(&bitcoind_1, &bitcoind_2).unwrap();
+    connect(&bitcoind_2, &utreexod_1).unwrap();
+    connect(&utreexod_1, &utreexod_2).unwrap();
+    connect(&utreexod_2, &bitcoind_1).unwrap();
 }


### PR DESCRIPTION
Closes #30 

Implement the `connect` free function that takes in two `&Node` and connects the first to the other.

This is more ergonomic than `node_a.connect(&node_b)` (albeit not a lot).

## Changelog
```
- Add `connect`
```