### PR TITLE
Bump `cargo-rbmt` to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ allowed_duplicates = [
 
 [package.metadata.rbmt.toolchains]
 stable = "1.95.0"
-nightly = "nightly-2026-03-18"
+nightly = "nightly-2026-05-17"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Available recipes:
     lock       # Regenerate Cargo-recent.lock and Cargo-minimal.lock [alias: l]
     pre-push   # Run pre-push checks [alias: p]
     test       # Run tests across all toolchains and lockfiles [alias: t]
+    toolchains # Update Stable and Nightly toolchains
     zizmor     # Run Zizmor Static Analysis [alias: z]
 ```
 

--- a/justfile
+++ b/justfile
@@ -21,13 +21,13 @@ audit:
 
 [doc: "Build `halfin`"]
 build:
-    RBMT_LOG_LEVEL=progress cargo rbmt run build
+    RBMT_LOG_LEVEL=verbose cargo rbmt run build
 
 [doc: "Check code formatting, compilation, and linting"]
 check:
-    RBMT_LOG_LEVEL=progress cargo rbmt fmt --check
-    RBMT_LOG_LEVEL=progress cargo rbmt lint
-    RBMT_LOG_LEVEL=progress cargo rbmt docsrs
+    RBMT_LOG_LEVEL=verbose cargo rbmt fmt --check
+    RBMT_LOG_LEVEL=verbose cargo rbmt lint
+    RBMT_LOG_LEVEL=verbose cargo rbmt docsrs
 
 [doc: "Checks whether all commits in this branch are signed"]
 check-sigs:
@@ -35,15 +35,15 @@ check-sigs:
 
 [doc: "Generate documentation"]
 doc:
-    RBMT_LOG_LEVEL=progress cargo rbmt docsrs
+    RBMT_LOG_LEVEL=verbose cargo rbmt docsrs
 
 [doc: "Generate and open documentation"]
 doc-open:
-    RBMT_LOG_LEVEL=progress cargo rbmt docsrs --open
+    RBMT_LOG_LEVEL=verbose cargo rbmt docsrs --open
 
 [doc: "Format code"]
 fmt:
-    RBMT_LOG_LEVEL=progress cargo rbmt fmt
+    RBMT_LOG_LEVEL=verbose cargo rbmt fmt
 
 [doc: "Regenerate Cargo-recent.lock and Cargo-minimal.lock"]
 lock:
@@ -52,6 +52,11 @@ lock:
 [doc: "Run tests across all toolchains and lockfiles"]
 test:
     RBMT_LOG_LEVEL=verbose cargo rbmt test
+
+[doc: "Update Stable and Nightly toolchains"]
+toolchains:
+    RBMT_LOG_LEVEL=verbose cargo rbmt toolchains --update-stable
+    RBMT_LOG_LEVEL=verbose cargo rbmt toolchains --update-nightly
 
 [doc: "Run Zizmor Static Analysis"]
 zizmor:

--- a/rbmt-version
+++ b/rbmt-version
@@ -1,1 +1,1 @@
-cargo-rbmt-0.2.1
+cargo-rbmt-0.3.0


### PR DESCRIPTION
## Changelog
```
- Bump `cargo-rbmt` to v0.3.0
- Bump nightly toolchain to `nightly-2026-05-17`
- Add `toolchains` recipe
```