### PR TITLE
Automated Rust Toolchain Update 2026-05-27-fa9f

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ allowed_duplicates = [
 
 [package.metadata.rbmt.toolchains]
 stable = "1.95.0"
-nightly = "nightly-2026-05-19"
+nightly = "nightly-2026-05-26"


### PR DESCRIPTION
## Changelog
```
- Update Nightly toolchain from nightly-2026-05-19 to nightly-2026-05-26
```