### PR TITLE
utreexod: don't error on IBD if connecting at height 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,13 +200,13 @@ pub fn wait_for_height<N: Node>(node: &N, height: u32) -> Result<(), Error> {
 
     let start = Instant::now();
     while start.elapsed() < N::wait_timeout() {
-        if node.get_chain_tip().unwrap() >= height {
+        if node.get_chain_tip().unwrap_or(0) >= height {
             return Ok(());
         }
         thread::sleep(N::poll_interval());
     }
 
-    let curr_height = node.get_chain_tip().unwrap();
+    let curr_height = node.get_chain_tip().unwrap_or(0);
     Err(Error::ChainSyncTimeOut((
         height,
         curr_height,
@@ -231,13 +231,13 @@ pub fn wait_for_height_with_timeout<N: Node>(
 
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if node.get_chain_tip().unwrap() >= height {
+        if node.get_chain_tip().unwrap_or(0) >= height {
             return Ok(());
         }
         thread::sleep(N::poll_interval());
     }
 
-    let curr_height = node.get_chain_tip().unwrap();
+    let curr_height = node.get_chain_tip().unwrap_or(0);
     Err(Error::ChainSyncTimeOut((height, curr_height, timeout)))
 }
 
@@ -253,13 +253,13 @@ pub fn wait_for_filter_height<N: Node>(node: &N, filter_height: u32) -> Result<(
 
     let start = Instant::now();
     while start.elapsed() < N::wait_timeout() {
-        if node.get_filter_tip().unwrap() >= filter_height {
+        if node.get_filter_tip().unwrap_or(0) >= filter_height {
             return Ok(());
         }
         thread::sleep(N::poll_interval());
     }
 
-    let curr_filter_height = node.get_filter_tip().unwrap();
+    let curr_filter_height = node.get_filter_tip().unwrap_or(0);
     Err(Error::ChainSyncTimeOut((
         filter_height,
         curr_filter_height,

--- a/tests/bitcoind_utreexod.rs
+++ b/tests/bitcoind_utreexod.rs
@@ -42,34 +42,30 @@ fn test_bitcoind_blocks_propagate_to_utreexod() {
     assert_eq!(utreexod.get_chain_tip().unwrap(), 21);
 }
 
-// Doesn't work
-// BitcoinD needs to mine and only then connect to UtreexoD.
-// UtreexoD appears to not sync headers after the initial handshake.
+/// Verify that blocks mined on [`BitcoinD`] *after* a [`UtreexoD`] peer is
+/// connected propagate live to that peer.
+///
+/// The chain must be bootstrapped with at least one block before connecting.
+/// If [`BitcoinD`] is in initial block download and never establishes the
+/// header-sync relationship, and blocks mined afterwards are never announced.
+/// Mining one block first takes [`BitcoinD`] out of IBD, and thenlive block
+/// relay works.
 #[test]
-#[ignore]
 fn test_bitcoind_utreexod_chain_sync() {
     let bitcoind = BitcoinD::new().unwrap();
     let utreexod = UtreexoD::new().unwrap();
 
+    // Bootstrap out of genesis, then connect and sync.
+    bitcoind.generate(1).unwrap();
     connect(&bitcoind, &utreexod).unwrap();
+    wait_for_height(&utreexod, 1).unwrap();
 
-    let bitcoind_peers = bitcoind
-        .get_rpc_client()
-        .call::<serde_json::Value>("getpeerinfo", &[])
-        .unwrap();
-    let utreexod_peers = utreexod
-        .get_rpc_client()
-        .call::<serde_json::Value>("getpeerinfo", &[])
-        .unwrap();
-
-    println!("bitcoind peers: {:#?}", bitcoind_peers);
-    println!("utreexod peers: {:#?}", utreexod_peers);
+    // Blocks mined after connecting must propagate live.
+    bitcoind.generate(10).unwrap();
+    wait_for_height(&utreexod, 11).unwrap();
+    assert_eq!(utreexod.get_chain_tip().unwrap(), 11);
 
     bitcoind.generate(10).unwrap();
-    wait_for_height(&utreexod, 10).unwrap();
-    assert_eq!(utreexod.get_chain_tip().unwrap(), 10);
-
-    bitcoind.generate(10).unwrap();
-    wait_for_height(&utreexod, 20).unwrap();
-    assert_eq!(utreexod.get_chain_tip().unwrap(), 20);
+    wait_for_height(&utreexod, 21).unwrap();
+    assert_eq!(utreexod.get_chain_tip().unwrap(), 21);
 }


### PR DESCRIPTION
`utreexod` wont initiate header sync if connecting to a `bitcoind` that's at height=0 and mines blocks after. 

Don't `unwrap()` on `get_chain_tip()` when still at zero.