### PR TITLE
Automated Rust Toolchain Update 2026-06-03-6865

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ let-and-return = "allow"
 
 [package.metadata.rbmt.toolchains]
 stable = "1.96.0"
-nightly = "nightly-2026-05-26"
+nightly = "nightly-2026-06-02"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "=1.5.0" # blame: tracing-subsbcriber
 let-and-return = "allow"
 
 [package.metadata.rbmt.toolchains]
-stable = "1.95.0"
+stable = "1.96.0"
 nightly = "nightly-2026-05-26"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Changelog
```
- Update Stable toolchain from 1.95.0 to 1.96.0
- Update Nightly toolchain from nightly-2026-05-26 to nightly-2026-06-02
```