### PR TITLE
Drop `x86_64-apple-darwin` from cross compilation workflow

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -24,11 +24,6 @@ jobs:
                       os: MacOS
                       arch: Apple Silicon (ARM64)
 
-                    - runner: macos-13
-                      target: x86_64-apple-darwin
-                      os: MacOS
-                      arch: Intel Silicon (x86_64)
-
                     - runner: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       os: Linux


### PR DESCRIPTION
Apparently GitHub is sunsetting the `macos-13` (Intel Silicon + MacOS) runner, as the job has been waiting to be picked up by one for many hours.