### PR TITLE
Automated Rust Toolchain Update 2026-07-01-93c3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.rbmt]
-toolchains = { stable = "1.96.0", nightly = "nightly-2026-06-23" }
+toolchains = { stable = "1.96.1", nightly = "nightly-2026-06-23" }
 tools = { cargo-audit = "=0.22.2", zizmor = "=1.26.1" }
 test = { sample_strategy = "all" }
 lint = { allowed_duplicates = ["base64"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.rbmt]
-toolchains = { stable = "1.96.1", nightly = "nightly-2026-06-23" }
+toolchains = { stable = "1.96.1", nightly = "nightly-2026-06-30" }
 tools = { cargo-audit = "=0.22.2", zizmor = "=1.26.1" }
 test = { sample_strategy = "all" }
 lint = { allowed_duplicates = ["base64"] }


### PR DESCRIPTION
## Changelog
```
- Update Stable toolchain from 1.96.0 to 1.96.1
- Update Nightly toolchain from nightly-2026-06-23 to nightly-2026-06-30
```