### PR TITLE
Automated Rust Toolchain Update 2026-07-08-be74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.rbmt]
-toolchains = { stable = "1.96.1", nightly = "nightly-2026-06-30" }
+toolchains = { stable = "1.96.1", nightly = "nightly-2026-07-07" }
 tools = { cargo-audit = "=0.22.2", zizmor = "=1.26.1" }
 test = { sample_strategy = "all" }
 lint = { allowed_duplicates = ["base64"] }


### PR DESCRIPTION
## Changelog
```
- Update Nightly toolchain from nightly-2026-06-30 to nightly-2026-07-07
```