### PR TITLE
Automated Rust Toolchain Update 2026-07-29-58aa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ lazy_static = { version = "=1.5.0" } # blame: tracing-subsbcriber
 
 [package.metadata.rbmt]
 version = "0.5.1"
-toolchains = { stable = "1.97.1", nightly = "nightly-2026-07-22" }
+toolchains = { stable = "1.97.1", nightly = "nightly-2026-07-29" }
 tools = { cargo-audit = "=0.22.2", zizmor = "=1.26.1" }
 test = { sample_strategy = "all" }
 lint = { allowed_duplicates = ["base64"] }


### PR DESCRIPTION
## Changelog
```
- Update Nightly toolchain from nightly-2026-07-22 to nightly-2026-07-29
```