### PR TITLE
Automated Rust Toolchain Update 2026-08-26-3da9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ lazy_static = { version = "=1.5.0" } # blame: tracing-subsbcriber@0.3.23
 
 [package.metadata.rbmt]
 version = "0.5.3"
-toolchains = { stable = "1.98.0", nightly = "nightly-2026-08-19" }
+toolchains = { stable = "1.98.0", nightly = "nightly-2026-08-26" }
 lint = { allowed_duplicates = [
     "base64",
     "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ lazy_static = { version = "=1.5.0" } # blame: tracing-subsbcriber@0.3.23
 
 [package.metadata.rbmt]
 version = "0.5.3"
-toolchains = { stable = "1.97.1", nightly = "nightly-2026-08-19" }
+toolchains = { stable = "1.98.0", nightly = "nightly-2026-08-19" }
 lint = { allowed_duplicates = [
     "base64",
     "bitflags",


### PR DESCRIPTION
## Changelog
```
- Update Stable toolchain from 1.97.1 to 1.98.0
- Update Nightly toolchain from nightly-2026-08-19 to nightly-2026-08-26
```