### PR TITLE
Automated Rust Toolchain Update 2026-09-02-fbde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ lazy_static = { version = "=1.5.0" } # blame: tracing-subsbcriber@0.3.23
 
 [package.metadata.rbmt]
 version = "0.5.3"
-toolchains = { stable = "1.98.0", nightly = "nightly-2026-08-26" }
+toolchains = { stable = "1.98.0", nightly = "nightly-2026-09-02" }
 lint = { allowed_duplicates = [
     "base64",
     "bitflags",


### PR DESCRIPTION
## Changelog
```
- Update Nightly toolchain from nightly-2026-08-26 to nightly-2026-09-02
```